### PR TITLE
add support for m.weibo.cn

### DIFF
--- a/blacklight-base/src/main/AndroidManifest.xml
+++ b/blacklight-base/src/main/AndroidManifest.xml
@@ -73,6 +73,9 @@
 					android:host="weibo.cn"
 					android:scheme="http"/>
 				<data
+					android:host="m.weibo.cn"
+					android:scheme="http"/>
+				<data
 					android:host="www.weibo.cn"
 					android:scheme="http"/>
 			</intent-filter>

--- a/blacklight-base/src/main/java/info/papdt/blacklight/support/WeiboUrlUtility.java
+++ b/blacklight-base/src/main/java/info/papdt/blacklight/support/WeiboUrlUtility.java
@@ -42,6 +42,7 @@ public class WeiboUrlUtility
 		"weibo.com",
 		"www.weibo.com",
 		"weibo.cn",
+		"m.weibo.cn",
 		"www.weibo.cn"
 	);
 


### PR DESCRIPTION
m.weibo.cn is used in links to status longer than 140