### PR TITLE
修复API level23 单条微博页面滑动时的闪退

### DIFF
--- a/blacklight-base/src/main/java/info/papdt/blacklight/ui/common/ToolbarActivity.java
+++ b/blacklight-base/src/main/java/info/papdt/blacklight/ui/common/ToolbarActivity.java
@@ -21,19 +21,17 @@ package info.papdt.blacklight.ui.common;
 
 import android.os.Build;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.view.Window;
-
 import info.papdt.blacklight.R;
 import info.papdt.blacklight.support.Utility;
 
-public abstract class ToolbarActivity extends ActionBarActivity
+public abstract class ToolbarActivity extends AppCompatActivity
 {
 	protected Toolbar mToolbar;
 	protected int mLayout = 0;
-	
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		if (Build.VERSION.SDK_INT >= 21) {

--- a/blacklight-base/src/main/java/info/papdt/blacklight/ui/statuses/AbsTimeLineFragment.java
+++ b/blacklight-base/src/main/java/info/papdt/blacklight/ui/statuses/AbsTimeLineFragment.java
@@ -259,7 +259,7 @@ SwipeRefreshLayout.OnRefreshListener, MainActivity.Refresher, MainActivity.Heade
 		if (mShadow != null)
 			mShadow.bringToFront();
 
-		if (mFastScrollEnabled) {
+		if (mFastScrollEnabled && !(getActivity() instanceof SingleActivity)) {
 			mOrbit.setVisibility(View.VISIBLE);
 			mScroller.setVisibility(View.VISIBLE);
 

--- a/blacklight-base/src/main/res/layout/single_weibo_content.xml
+++ b/blacklight-base/src/main/res/layout/single_weibo_content.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+* Copyright (C) 2014 Peter Cai
+*
+* This file is part of BlackLight
+*
+* BlackLight is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* BlackLight is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with BlackLight.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<RelativeLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:app="http://schemas.android.com/apk/res-auto"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+	<RelativeLayout
+		android:id="@+id/weibo_user"
+		android:layout_alignParentLeft="true"
+		android:layout_marginLeft="5dp"
+		android:layout_marginTop="5dp"
+		android:layout_marginBottom="5dp"
+		android:layout_width="wrap_content"
+		android:layout_height="50dp">
+
+		<de.hdodenhof.circleimageview.CircleImageView
+			android:id="@+id/weibo_avatar"
+			android:layout_width="36dp"
+			android:layout_height="36dp"
+			android:layout_centerVertical="true"
+			android:layout_marginLeft="10dp"
+			android:src="@color/gray"
+			style="?android:attr/buttonBarButtonStyle"/>
+
+		<TextView
+			android:id="@+id/weibo_name"
+			android:layout_toRightOf="@id/weibo_avatar"
+			android:layout_toLeftOf="@+id/weibo_popup"
+			android:layout_marginLeft="10dp"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_centerVertical="true"
+			android:textSize="15dp"
+			android:textColor="?attr/CardForeground"
+			android:text="Author Name"
+			android:singleLine="true"
+			android:ellipsize="end"/>
+
+		<info.papdt.blacklight.ui.common.TintImageView
+			android:id="@+id/weibo_popup"
+			android:layout_width="45dp"
+			android:layout_height="50dp"
+			android:layout_centerVertical="true"
+			android:layout_alignParentRight="true"
+			android:layout_marginRight="5dp"
+			android:scaleType="centerInside"
+			android:src="@drawable/ic_menu_more"
+			app:tintColor="?attr/CardForeground"
+			style="?android:attr/buttonBarButtonStyle"/>
+
+	</RelativeLayout>
+
+	<info.papdt.blacklight.ui.common.HackyTextView
+		android:layout_height="wrap_content"
+		android:text="Content"
+		android:layout_width="match_parent"
+		android:id="@+id/weibo_content"
+		android:textSize="14sp"
+		android:textColor="?attr/CardForeground"
+		android:textColorLink="?attr/colorAccent"
+		android:lineSpacingExtra="4dp"
+		android:layout_marginTop="5dp"
+		android:layout_marginLeft="15dp"
+		android:layout_marginRight="15dp"
+		android:paddingBottom="15dp"
+		android:layout_below="@id/weibo_user"/>
+
+
+	<include layout="@layout/weibo_pics" android:id="@+id/weibo_pics" />
+	<TextView
+		android:id="@+id/weibo_date"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:text="Date"
+		android:textSize="12sp"
+		android:textColor="?attr/CardSubColor"
+		android:layout_below="@id/weibo_pics"
+		android:layout_marginLeft="15dp"
+		android:layout_marginRight="2dp"
+		android:paddingBottom="10dp"/>
+
+	<TextView
+		android:id="@+id/weibo_from_divide"
+		android:layout_below="@id/weibo_pics"
+		android:layout_toRightOf="@id/weibo_date"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:textSize="12sp"
+		android:textColor="?attr/CardSubColor"
+		android:text="|"/>
+
+	<TextView
+		android:id="@+id/weibo_from"
+		android:layout_toRightOf="@id/weibo_from_divide"
+		android:layout_below="@id/weibo_pics"
+		android:layout_marginLeft="2dp"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:textSize="12sp"
+		android:textColor="?attr/CardSubColor"
+		android:text="From"/>
+
+	<LinearLayout
+		android:id="@+id/weibo_comment_and_retweet"
+		android:layout_below="@id/weibo_pics"
+		android:layout_toRightOf="@id/weibo_from"
+		android:layout_marginLeft="5dp"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:orientation="horizontal"
+		android:gravity="center_vertical">
+
+		<info.papdt.blacklight.ui.common.TintImageView
+			android:src="@drawable/ic_like"
+			android:scaleType="centerInside"
+			android:layout_width="18dp"
+			android:layout_height="18dp"
+			android:layout_marginRight="2dp"
+			app:tintColor="?attr/CardSubColor"/>
+
+		<TextView
+			android:id="@+id/weibo_attitudes"
+			android:text="0"
+			android:textSize="12sp"
+			android:textColor="?attr/CardSubColor"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginRight="2dp"/>
+
+
+		<info.papdt.blacklight.ui.common.TintImageView
+			android:src="@drawable/ic_repost"
+			android:scaleType="centerInside"
+			android:layout_width="18dp"
+			android:layout_height="18dp"
+			android:layout_marginRight="2dp"
+			app:tintColor="?attr/CardSubColor"/>
+
+		<TextView
+			android:id="@+id/weibo_retweet"
+			android:text="0"
+			android:textSize="12sp"
+			android:textColor="?attr/CardSubColor"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginRight="2dp"/>
+
+
+		<info.papdt.blacklight.ui.common.TintImageView
+			android:src="@drawable/ic_comment_1"
+			android:scaleType="centerInside"
+			android:layout_width="18dp"
+			android:layout_height="18dp"
+			android:layout_marginRight="2dp"
+			app:tintColor="?attr/CardSubColor"/>
+
+		<TextView
+			android:id="@+id/weibo_comments"
+			android:text="0"
+			android:textSize="12sp"
+			android:textColor="?attr/CardSubColor"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginRight="2dp"/>
+
+	</LinearLayout>
+</RelativeLayout>

--- a/blacklight-base/src/main/res/layout/weibo_content.xml
+++ b/blacklight-base/src/main/res/layout/weibo_content.xml
@@ -17,177 +17,24 @@
 * You should have received a copy of the GNU General Public License
 * along with BlackLight.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<RelativeLayout
+<LinearLayout
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:app="http://schemas.android.com/apk/res-auto"
 	android:layout_width="match_parent"
-	android:layout_height="match_parent">
+	android:layout_height="match_parent"
+	android:orientation="vertical"
+>
 
-	<RelativeLayout
-		android:id="@+id/weibo_user"
-		android:layout_alignParentLeft="true"
-		android:layout_marginLeft="5dp"
-		android:layout_marginTop="5dp"
-		android:layout_marginBottom="5dp"
-		android:layout_width="wrap_content"
-		android:layout_height="50dp">
-
-		<de.hdodenhof.circleimageview.CircleImageView
-			android:id="@+id/weibo_avatar"
-			android:layout_width="36dp"
-			android:layout_height="36dp"
-			android:layout_centerVertical="true"
-			android:layout_marginLeft="10dp"
-			android:src="@color/gray"
-			style="?android:attr/buttonBarButtonStyle"/>
-
-		<TextView
-			android:id="@+id/weibo_name"
-			android:layout_toRightOf="@id/weibo_avatar"
-			android:layout_toLeftOf="@+id/weibo_popup"
-			android:layout_marginLeft="10dp"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:layout_centerVertical="true"
-			android:textSize="15dp"
-			android:textColor="?attr/CardForeground"
-			android:text="Author Name"
-			android:singleLine="true"
-			android:ellipsize="end"/>
-
-		<info.papdt.blacklight.ui.common.TintImageView
-			android:id="@+id/weibo_popup"
-			android:layout_width="45dp"
-			android:layout_height="50dp"
-			android:layout_centerVertical="true"
-			android:layout_alignParentRight="true"
-			android:layout_marginRight="5dp"
-			android:scaleType="centerInside"
-			android:src="@drawable/ic_menu_more"
-			app:tintColor="?attr/CardForeground"
-			style="?android:attr/buttonBarButtonStyle"/>
-
-	</RelativeLayout>
-
-	<info.papdt.blacklight.ui.common.HackyTextView
-		android:layout_height="wrap_content"
-		android:text="Content"
-		android:layout_width="match_parent"
-		android:id="@+id/weibo_content"
-		android:textSize="16sp"
-		android:textColor="?attr/CardForeground"
-		android:textColorLink="?attr/colorAccent"
-		android:lineSpacingExtra="4dp"
-		android:layout_marginTop="5dp"
-		android:layout_marginLeft="15dp"
-		android:layout_marginRight="15dp"
-		android:paddingBottom="15dp"
-		android:layout_below="@id/weibo_user"/>
-
-	<TextView
-		android:id="@+id/weibo_date"
-		android:layout_width="wrap_content"
-		android:layout_height="wrap_content"
-		android:text="Date"
-		android:textSize="12sp"
-		android:textColor="?attr/CardSubColor"
-		android:layout_below="@id/weibo_content"
-		android:layout_marginLeft="15dp"
-		android:layout_marginRight="2dp"
-		android:paddingBottom="10dp"/>
-
-	<TextView
-		android:id="@+id/weibo_from_divide"
-		android:layout_below="@id/weibo_content"
-		android:layout_toRightOf="@id/weibo_date"
-		android:layout_width="wrap_content"
-		android:layout_height="wrap_content"
-		android:textSize="12sp"
-		android:textColor="?attr/CardSubColor"
-		android:text="|"/>
-
-	<TextView
-		android:id="@+id/weibo_from"
-		android:layout_toRightOf="@id/weibo_from_divide"
-		android:layout_below="@id/weibo_content"
-		android:layout_marginLeft="2dp"
-		android:layout_width="wrap_content"
-		android:layout_height="wrap_content"
-		android:textSize="12sp"
-		android:textColor="?attr/CardSubColor"
-		android:text="From"/>
-
-	<LinearLayout
-		android:id="@+id/weibo_comment_and_retweet"
-		android:layout_below="@id/weibo_content"
-		android:layout_toRightOf="@id/weibo_from"
-		android:layout_marginLeft="5dp"
-		android:layout_width="wrap_content"
-		android:layout_height="wrap_content"
-		android:orientation="horizontal"
-		android:gravity="center_vertical">
-
-		<info.papdt.blacklight.ui.common.TintImageView
-			android:src="@drawable/ic_like"
-			android:scaleType="centerInside"
-			android:layout_width="18dp"
-			android:layout_height="18dp"
-			android:layout_marginRight="2dp"
-			app:tintColor="?attr/CardSubColor"/>
-
-		<TextView
-			android:id="@+id/weibo_attitudes"
-			android:text="0"
-			android:textSize="12sp"
-			android:textColor="?attr/CardSubColor"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:layout_marginRight="2dp"/>
-
-
-		<info.papdt.blacklight.ui.common.TintImageView
-			android:src="@drawable/ic_repost"
-			android:scaleType="centerInside"
-			android:layout_width="18dp"
-			android:layout_height="18dp"
-			android:layout_marginRight="2dp"
-			app:tintColor="?attr/CardSubColor"/>
-
-		<TextView
-			android:id="@+id/weibo_retweet"
-			android:text="0"
-			android:textSize="12sp"
-			android:textColor="?attr/CardSubColor"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:layout_marginRight="2dp"/>
-
-
-		<info.papdt.blacklight.ui.common.TintImageView
-			android:src="@drawable/ic_comment_1"
-			android:scaleType="centerInside"
-			android:layout_width="18dp"
-			android:layout_height="18dp"
-			android:layout_marginRight="2dp"
-			app:tintColor="?attr/CardSubColor"/>
-
-		<TextView
-			android:id="@+id/weibo_comments"
-			android:text="0"
-			android:textSize="12sp"
-			android:textColor="?attr/CardSubColor"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:layout_marginRight="2dp"/>
-
-	</LinearLayout>
-
+	<include layout="@layout/single_weibo_content"
+			 android:layout_height="wrap_content"
+			 android:layout_width="match_parent"
+	/>
 	<RelativeLayout
 		android:layout_height="wrap_content"
 		android:layout_width="match_parent"
 		android:id="@+id/weibo_origin"
 		android:background="?attr/CardOrigBackground"
-		android:layout_below="@id/weibo_date"
+		android:layout_alignParentBottom="true"
 		android:visibility="gone">
 
 		<View
@@ -197,69 +44,11 @@
 			android:background="?attr/CardDivider"
 			android:layout_alignParentTop="true"/>
 
-		<info.papdt.blacklight.ui.common.HackyTextView
-			android:layout_height="wrap_content"
-			android:text="Content"
-			android:layout_width="match_parent"
-			android:id="@+id/weibo_orig_content"
-			android:layout_marginLeft="15dp"
-			android:layout_marginTop="10dp"
-			android:layout_marginRight="15dp"
-			android:paddingBottom="10dp"
-			android:textSize="16sp"
-			android:textColor="?attr/CardForeground"
-			android:textColorLink="?attr/colorAccent"
-			android:lineSpacingExtra="4dp"/>
+		<include layout="@layout/single_weibo_content"
+		/>
 
 	</RelativeLayout>
 
-	<HorizontalScrollView
-		android:layout_height="wrap_content"
-		android:layout_width="match_parent"
-		android:background="?attr/CardOrigBackground"
-		android:paddingLeft="15dp"
-		android:paddingTop="5dp"
-		android:paddingRight="15dp"
-		android:paddingBottom="10dp"
-		android:id="@+id/weibo_pics_scroll"
-		android:layout_below="@id/weibo_origin"
-		android:visibility="gone">
 
-		<LinearLayout
-			android:layout_height="wrap_content"
-			android:layout_width="wrap_content"
-			android:orientation="horizontal"
-			android:id="@+id/weibo_pics">
 
-			<include
-				layout="@layout/weibo_pic"/>
-
-			<include
-				layout="@layout/weibo_pic"/>
-
-			<include
-				layout="@layout/weibo_pic"/>
-
-			<include
-				layout="@layout/weibo_pic"/>
-
-			<include
-				layout="@layout/weibo_pic"/>
-
-			<include
-				layout="@layout/weibo_pic"/>
-
-			<include
-				layout="@layout/weibo_pic"/>
-
-			<include
-				layout="@layout/weibo_pic"/>
-
-			<include
-				layout="@layout/weibo_pic"/>
-
-		</LinearLayout>
-
-	</HorizontalScrollView>
-
-</RelativeLayout>
+</LinearLayout>

--- a/blacklight-base/src/main/res/layout/weibo_pic.xml
+++ b/blacklight-base/src/main/res/layout/weibo_pic.xml
@@ -19,8 +19,8 @@
 -->
 <ImageView
 	xmlns:android="http://schemas.android.com/apk/res/android"
-	android:layout_width="68dp"
-	android:layout_height="100dp"
+	android:layout_width="80dp"
+	android:layout_height="80dp"
 	android:background="@color/gray"
 	android:scaleType="centerCrop"
 	android:layout_marginRight="5dp"/>

--- a/blacklight-base/src/main/res/layout/weibo_pics.xml
+++ b/blacklight-base/src/main/res/layout/weibo_pics.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+* Copyright (C) 2014 Peter Cai
+*
+* This file is part of BlackLight
+*
+* BlackLight is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* BlackLight is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with BlackLight.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<TableLayout
+		xmlns:android="http://schemas.android.com/apk/res/android"
+		android:layout_height="wrap_content"
+		android:layout_width="wrap_content"
+		android:layout_marginLeft="20dp"
+		android:layout_below="@id/weibo_content"
+		android:id="@+id/weibo_pics">
+	<LinearLayout
+			android:layout_height="wrap_content"
+			android:layout_width="wrap_content"
+			android:layout_marginBottom="5dp"
+	>
+		<include
+				layout="@layout/weibo_pic"/>
+
+		<include
+				layout="@layout/weibo_pic"/>
+
+		<include
+				layout="@layout/weibo_pic"/>
+	</LinearLayout>
+	<LinearLayout
+			android:layout_height="wrap_content"
+			android:layout_width="wrap_content"
+			android:layout_marginBottom="5dp">
+		<include
+				layout="@layout/weibo_pic"/>
+
+		<include
+				layout="@layout/weibo_pic"/>
+
+		<include
+				layout="@layout/weibo_pic"/>
+	</LinearLayout>
+	<LinearLayout
+			android:layout_height="wrap_content"
+			android:layout_width="wrap_content"
+			android:layout_marginBottom="5dp">
+		<include
+				layout="@layout/weibo_pic"/>
+
+		<include
+				layout="@layout/weibo_pic"/>
+
+		<include
+				layout="@layout/weibo_pic"/>
+	</LinearLayout>
+</TableLayout>
+			


### PR DESCRIPTION
修复API level23 单条微博页面滑动时的闪退
原因是268行ViewCompat.setElevation(mScroller, 5.0f);导致
